### PR TITLE
Agregar botón del repositorio de GitHub en la página de inicio

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,13 @@
     <div class="container">
       <h1>🎉 Primera colaboración Open Source</h1>
 
+
+     <div class="container-repository-button">
+        <a href="https://github.com/moudev/primera-colaboracion-open-source" class="repository-button">
+          Repositorio de GitHub
+        </a>
+      </div>
+
     <h2>📍 Aspectos Generales</h2>
     <p>
       El objetivo de la iniciativa es explicar un poco sobre cómo realizar contribuciones a proyectos Open Source, los cuales en este caso están alojados en la plataforma GitHub.
@@ -125,6 +132,9 @@
         Repositorio de GitHub
       </a>
       el cual tiene una guía con todos los pasos necesarios.
+      <a href="https://twitter.com/_codemart">
+        @_codemart
+      </a>
     </footer>
     </div>
   </body>
@@ -195,6 +205,23 @@
 
   h1, h2, span, a {
     color: #D07AC6;
+  }
+
+  .container-repository-button {
+    display: flex;
+    justify-content: center;
+    margin: 1rem auto 3rem auto;
+  }
+
+  .repository-button {
+    padding: 1.5rem;
+    border: none;
+    background-color: #0069FF;
+    border-radius: 30px;
+    color: white;
+    font-size: 1rem;
+    font-weight: 600;
+    text-align: center;
   }
 
   .projects {


### PR DESCRIPTION
**📍 Descripción**
---

Agregando botón que redirige hacia el repositorio de GitHub. Los colores son tomados de la página oficial del Hacktoberfest.

**📷 Capturas**
---

- Botón
![Screenshot_2020-10-11 Te ayudo a completar el Hacktoberfest 2020(1)](https://user-images.githubusercontent.com/13499566/95694533-c4b1ad80-0bef-11eb-9c67-25190142bce7.png)




